### PR TITLE
Support macos cmd-q / menu-quit

### DIFF
--- a/src/main/java/it/usna/shellyscan/Main.java
+++ b/src/main/java/it/usna/shellyscan/Main.java
@@ -34,9 +34,6 @@ import it.usna.swing.UsnaSwingUtils;
 import it.usna.util.CLI;
 
 public class Main {
-	static {
-		System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS"); // OSX specific - cmd-Q / -Dapple.eawt.quitStrategy=CLOSE_ALL_WINDOWS
-	}
 	public final static String APP_NAME = "Shelly Scanner";
 	public final static String VERSION = "1.2.4";
 	public final static String VERSION_CODE = "001.002.004r200"; // r0xx alpha; r1xx beta; r2xx stable

--- a/src/main/java/it/usna/shellyscan/Main.java
+++ b/src/main/java/it/usna/shellyscan/Main.java
@@ -34,6 +34,9 @@ import it.usna.swing.UsnaSwingUtils;
 import it.usna.util.CLI;
 
 public class Main {
+	static {
+		System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS");  // OSX specific - cmd-Q / -Dapple.eawt.quitStrategy=CLOSE_ALL_WINDOWS
+	}
 	public final static String APP_NAME = "Shelly Scanner";
 	public final static String VERSION = "1.2.4";
 	public final static String VERSION_CODE = "001.002.004r200"; // r0xx alpha; r1xx beta; r2xx stable


### PR DESCRIPTION
On mac-os cmd-q / menu-quit cause a hard exit of the application that needs to be explicitly captured. This is difficult to do in a portable way.
An option exists to cause cmd-q to close all windows, causing a normal shutdown. This applies this change.

Without this change a cmd-Q quit of shelly scanner prevents the settings & archive files from being stored

PR for attribution